### PR TITLE
Cache invalidation, more options, support for fragments.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -4,6 +4,14 @@
       android:versionCode="1"
       android:versionName="1.0"
       debuggable="true">
+      
+	<supports-screens
+        android:anyDensity="true"
+        android:largeScreens="true"
+        android:normalScreens="true"
+        android:resizeable="true"
+        android:smallScreens="true" />
+    
     <application android:icon="@drawable/icon" android:label="@string/app_name">
         <activity android:name=".MainActivity"
                   android:label="@string/app_name"

--- a/project.properties
+++ b/project.properties
@@ -8,4 +8,4 @@
 # project structure.
 
 # Project target.
-target=android-3
+target=android-8

--- a/src/com/fedorvlasov/lazylist/FileCache.java
+++ b/src/com/fedorvlasov/lazylist/FileCache.java
@@ -1,38 +1,92 @@
 package com.fedorvlasov.lazylist;
 
 import java.io.File;
+
+import com.fedorvlasov.lazylist.Utils;
+
 import android.content.Context;
+import android.os.Environment;
 
 public class FileCache {
     
     private File cacheDir;
+    private File tempDir;
     
-    public FileCache(Context context){
+    public FileCache(Context context, boolean allowInternal, boolean allowExternal){
         //Find the dir to save cached images
-        if (android.os.Environment.getExternalStorageState().equals(android.os.Environment.MEDIA_MOUNTED))
-            cacheDir=new File(android.os.Environment.getExternalStorageDirectory(),"LazyList");
-        else
-            cacheDir=context.getCacheDir();
-        if(!cacheDir.exists())
-            cacheDir.mkdirs();
+        if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED) &&
+        		allowExternal)  {
+        	//external cache
+            cacheDir=new File(Utils.getExternalFilesDir(context),"cache");
+            tempDir = cacheDir;
+        } else if (allowInternal) {
+        	//internal cache
+            cacheDir = context.getCacheDir();
+            tempDir = cacheDir;
+        }
+        else {
+        	//no file cache
+        	cacheDir = null;
+        	tempDir = context.getCacheDir();
+        }	
+        
+        if(cacheDir != null) {
+	        if(!cacheDir.exists())
+	            cacheDir.mkdirs();
+        }
     }
     
     public File getFile(String url){
-        //I identify images by hashcode. Not a perfect solution, good for the demo.
-        String filename=String.valueOf(url.hashCode());
+    	if(cacheDir == null) {
+    		return null;
+    	}
+    	
+        //I identify images by md5 hash of url
+        String filename = Utils.md5(url);
         //Another possible solution (thanks to grantland)
         //String filename = URLEncoder.encode(url);
         File f = new File(cacheDir, filename);
         return f;
-        
+    }
+    
+    public File getTempFile(String url) {
+    	File dir = cacheDir;
+    	if(dir == null) {
+    		dir = tempDir;
+    	}
+    	
+        //I identify images by md5 hash of url
+        String filename = Utils.md5(url) + ".tmp";
+        //Another possible solution (thanks to grantland)
+        //String filename = URLEncoder.encode(url);
+        File f = new File(dir, filename);
+        return f;
     }
     
     public void clear(){
+    	if(cacheDir == null) 
+    		return;
+    	
         File[] files=cacheDir.listFiles();
         if(files==null)
             return;
         for(File f:files)
             f.delete();
     }
+
+	public void clear(long deleteOlderThen) {
+		if(cacheDir == null) {
+			return;
+		}
+		
+		File[] files = cacheDir.listFiles();
+        if(files==null)
+            return;
+        for(File f:files) {
+        	if(f.lastModified() < deleteOlderThen) {
+        		f.delete();        		
+        	}
+        }
+	}
 
 }

--- a/src/com/fedorvlasov/lazylist/ImageLoader.java
+++ b/src/com/fedorvlasov/lazylist/ImageLoader.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
@@ -13,54 +14,171 @@ import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import android.app.Activity;
+import java.util.concurrent.ThreadFactory;
+
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.os.Handler;
+import android.util.DisplayMetrics;
+import android.util.Log;
 import android.widget.ImageView;
 
 public class ImageLoader {
     
-    MemoryCache memoryCache=new MemoryCache();
-    FileCache fileCache;
+	private static final String TAG = "ImageLoader";
+	
+	/**
+	 * Default time, after which is checked if image was changed on the server.
+	 */
+	private static final int TIME_TO_CHECK_CHANGES = 5 * 60 * 1000;
+	
+	/**
+	 * Default time, after which unused files will be deleted.
+	 */
+	private static final int TIME_TO_CLEAN_UNUSED_FILES = 5 * 60 * 60 * 1000;
+	
+	private static final String LAST_CLEAN_UP_TIME_KEY = "image-loader-last-clean-up";
+	
+    private MemoryCache memoryCache=new MemoryCache();
+    private FileCache fileCache;
     private Map<ImageView, String> imageViews=Collections.synchronizedMap(new WeakHashMap<ImageView, String>());
-    ExecutorService executorService; 
+    private ExecutorService executorService; 
+    private int stubDrawableId;
+    private int timeInMilisToCheckChanges = TIME_TO_CHECK_CHANGES;
+    private int timeInMilisToCleanUnusedFiles = TIME_TO_CLEAN_UNUSED_FILES;
+    private int imageWidth;
+    private int imageHeight;
+    private int originalImageDensity = DisplayMetrics.DENSITY_HIGH;
     
-    public ImageLoader(Context context){
-        fileCache=new FileCache(context);
-        executorService=Executors.newFixedThreadPool(5);
+    private Handler handler;
+    
+    /**
+     * Creates new image loader. Pleas set imageWidth and imageHeight parameters to use memory more efficiently.
+     * @param context context
+     * @param stubDrawableId id of default placeholder image
+     * @param allowInternal enables internal memory caching
+     * @param allowExternal enables external memory (usually SD card) caching
+     * @param imageWidth required width of image, you can set it to -1 to disable down-sampling
+     * @param imageHeight required height of image, you can set it to -1 to disable down-sampling
+     */
+    public ImageLoader(Context context, 
+    		int stubDrawableId, 
+    		boolean allowInternal, 
+    		boolean allowExternal,
+    		int imageWidth,
+    		int imageHeight) {
+        fileCache = new FileCache(context, allowInternal, allowExternal);
+        executorService = Executors.newFixedThreadPool(5, new ThreadFactory() {
+        	private int threadCount = 0;
+			@Override
+			public Thread newThread(Runnable r) {
+				Thread t = new Thread(r, "ImageLoader-" + threadCount ++);
+				t.setDaemon(true);
+				t.setPriority(Thread.NORM_PRIORITY - 1);
+				return t;
+			}
+		});
+        this.stubDrawableId = stubDrawableId;
+        this.imageWidth = imageWidth;
+        this.imageHeight = imageHeight;
     }
     
-    final int stub_id=R.drawable.stub;
-    public void DisplayImage(String url, ImageView imageView)
+    public void setMemoryCacheEnabled(boolean enabled) {
+    	if(enabled && memoryCache == null) {
+    		memoryCache = new MemoryCache();
+    	}
+    	
+    	if(!enabled) {
+    		memoryCache = null;
+    	}
+    }
+    
+    /**
+     * Sets the period in which unused files will be cleared. 
+     * Unused file is file, which was not loaded from cache for longer then period given as parameter
+     * @param timeToClean time in milliseconds
+     */
+    public void setTimeToCleanUnusedFiles(int timeToClean) {
+    	timeInMilisToCleanUnusedFiles = timeToClean;
+    }
+    
+    /**
+     * Time to check changes on server. After this time we check if the image change on the server.
+     * @param timeToCheck time in millis.
+     */
+    public void setTimeToCheckChanges(int timeToCheck) {
+    	timeInMilisToCheckChanges = timeToCheck;
+    }
+
+    /**
+     * Here you can set for what the density your images are on server. Default is high density.
+     * Set it to 0 to don't scale images for particular density.
+     * @param density density of images on server, or zero to don't care about densities
+     */
+    public void setOriginalImageDensity(int density) {
+    	originalImageDensity = density;
+    }
+    
+    public void displayImage(String url, ImageView imageView, Context context)
     {
+    	if(handler == null) {
+    		handler = new Handler();
+    	}
+    	
         imageViews.put(imageView, url);
-        Bitmap bitmap=memoryCache.get(url);
-        if(bitmap!=null)
+        
+        Bitmap bitmap = getBitmapFromMemoryCache(url);
+        
+        if(bitmap != null) {
             imageView.setImageBitmap(bitmap);
-        else
-        {
-            queuePhoto(url, imageView);
-            imageView.setImageResource(stub_id);
+        } else {
+        	imageView.setTag(url);
+            queuePhoto(url, imageView, context);
+            imageView.setImageResource(stubDrawableId);
         }
     }
+
+	private Bitmap getBitmapFromMemoryCache(String url) {
+		Bitmap bitmap;
+        if(memoryCache != null) {
+        	bitmap = memoryCache.get(url);
+        } else {
+        	bitmap = null;
+        }
+		return bitmap;
+	}
         
-    private void queuePhoto(String url, ImageView imageView)
+    private void queuePhoto(String url, ImageView imageView, Context context)
     {
-        PhotoToLoad p=new PhotoToLoad(url, imageView);
+        PhotoToLoad p=new PhotoToLoad(url, imageView, context);
         executorService.submit(new PhotosLoader(p));
     }
     
-    private Bitmap getBitmap(String url) 
+    private Bitmap getBitmapFromFileCache(String url, int targetDensity) 
     {
-        File f=fileCache.getFile(url);
+        File f = fileCache.getFile(url);
+        
+        if(f == null) {
+        	return null;
+        }
         
         //from SD cache
-        Bitmap b = decodeFile(f);
-        if(b!=null)
+        Bitmap b = decodeFile(f, targetDensity);
+        if(b != null) {        	
             return b;
-        
-        //from web
+        } else {
+        	f.delete();//maybe file is corrupted
+        	return null;
+        }
+    }
+
+	private Bitmap getBitmapFromWeb(String url, int targetDensity) {
+		File f = fileCache.getFile(url);
+		File tempFile = fileCache.getTempFile(url);
+		
+		//from web
         try {
             Bitmap bitmap=null;
             URL imageUrl = new URL(url);
@@ -68,20 +186,75 @@ public class ImageLoader {
             conn.setConnectTimeout(30000);
             conn.setReadTimeout(30000);
             conn.setInstanceFollowRedirects(true);
-            InputStream is=conn.getInputStream();
-            OutputStream os = new FileOutputStream(f);
-            Utils.CopyStream(is, os);
-            os.close();
-            bitmap = decodeFile(f);
+            
+            //not modified?
+            if(f != null) {
+	            conn.setIfModifiedSince(f.lastModified());
+	            if(conn.getResponseCode() == HttpURLConnection.HTTP_NOT_MODIFIED) {
+	            	conn.disconnect();
+	            	f.setLastModified(System.currentTimeMillis());//touch the file
+	            	return null;
+	            }
+            }
+            
+            downloadImage(tempFile, conn, url);
+            
+            bitmap = decodeFile(tempFile, targetDensity);
+            
+            if(f != null) {
+            	//if file cache is enabled, store the file there
+            	f.delete();
+            	tempFile.renameTo(f);
+            }
+            
             return bitmap;
         } catch (Exception ex){
-           ex.printStackTrace();
-           return null;
+        	Log.w(TAG, "Error when downloading image.", ex);
+        	return null;
+        } finally {
+        	tempFile.delete();
         }
-    }
+	}
+
+	/**
+	 * Downloads image to file f.
+	 * @param f file to be downloaded image ins
+	 * @param conn connection to download from
+	 * @param url file url
+	 * @throws IOException
+	 */
+	private void downloadImage(File f, HttpURLConnection conn, String url) throws IOException {
+		OutputStream os = null;
+		InputStream is = null;
+		
+		try {
+	        is = conn.getInputStream();
+	        os = new FileOutputStream(f);//use tempfile to avoid half-downloaded images
+
+			Utils.copyStream(is, os);
+			os.close();
+			
+			f.setLastModified(System.currentTimeMillis());
+		} finally {
+        	if(is != null) {
+        		try {
+        			is.close();
+        		} catch (Exception e) {
+					// never mind
+				}
+        	}
+        	if(os != null) {
+        		try {
+        			os.close();
+        		} catch (Exception e) {
+        			// never mind
+        		}
+        	}
+		}
+	}
 
     //decodes image and scales it to reduce memory consumption
-    private Bitmap decodeFile(File f){
+    private Bitmap decodeFile(File f, int targetDensity){
         try {
             //decode image size
             BitmapFactory.Options o = new BitmapFactory.Options();
@@ -89,20 +262,24 @@ public class ImageLoader {
             BitmapFactory.decodeStream(new FileInputStream(f),null,o);
             
             //Find the correct scale value. It should be the power of 2.
-            final int REQUIRED_SIZE=70;
+            int requiredImageWidth = imageWidth > 0 ? imageWidth : Integer.MAX_VALUE;
+            int requiredImageHeight = imageHeight > 0 ? imageHeight : Integer.MAX_VALUE;
             int width_tmp=o.outWidth, height_tmp=o.outHeight;
             int scale=1;
             while(true){
-                if(width_tmp/2<REQUIRED_SIZE || height_tmp/2<REQUIRED_SIZE)
+                if(width_tmp/2 < requiredImageWidth || height_tmp/2 < requiredImageHeight)
                     break;
                 width_tmp/=2;
                 height_tmp/=2;
                 scale*=2;
             }
-            
+            scale = 1;
             //decode with inSampleSize
             BitmapFactory.Options o2 = new BitmapFactory.Options();
-            o2.inSampleSize=scale;
+            o2.inScaled = true; //scale to target density
+            o2.inSampleSize = scale;
+            o2.inDensity = originalImageDensity;
+            o2.inTargetDensity = targetDensity;
             return BitmapFactory.decodeStream(new FileInputStream(f), null, o2);
         } catch (FileNotFoundException e) {}
         return null;
@@ -113,7 +290,8 @@ public class ImageLoader {
     {
         public String url;
         public ImageView imageView;
-        public PhotoToLoad(String u, ImageView i){
+        public Context context;
+        public PhotoToLoad(String u, ImageView i, Context activity) {
             url=u; 
             imageView=i;
         }
@@ -127,23 +305,73 @@ public class ImageLoader {
         
         @Override
         public void run() {
+        	int targetDensity = photoToLoad.imageView.getResources().getDisplayMetrics().densityDpi;
+
             if(imageViewReused(photoToLoad))
                 return;
-            Bitmap bmp=getBitmap(photoToLoad.url);
-            memoryCache.put(photoToLoad.url, bmp);
+            Bitmap bmp=getBitmapFromFileCache(photoToLoad.url, targetDensity);
+            if(bmp == null) {
+            	bmp = getBitmapFromWeb(photoToLoad.url, targetDensity);
+            }
+            if(memoryCache != null) {
+            	memoryCache.put(photoToLoad.url, bmp);
+            }
             if(imageViewReused(photoToLoad))
                 return;
-            BitmapDisplayer bd=new BitmapDisplayer(bmp, photoToLoad);
-            Activity a=(Activity)photoToLoad.imageView.getContext();
-            a.runOnUiThread(bd);
+            displayBitmap(bmp);
+            
+            //refresh cache after showing image
+            askServerFoChanges(targetDensity);
+            
+            //maybe cleanup?
+            cacheCleanup();
         }
+
+        /**
+         * Time to time cleans the cache up.
+         */
+		private void cacheCleanup() {
+			SharedPreferences prefs = photoToLoad.context.getSharedPreferences("image-loader-dkd43l", Context.MODE_PRIVATE);
+            long lastCleanupTime = prefs.getLong(LAST_CLEAN_UP_TIME_KEY, 0);
+            if(lastCleanupTime == 0) {
+            	prefs.edit().putLong(LAST_CLEAN_UP_TIME_KEY, System.currentTimeMillis()).commit();
+            } else if(lastCleanupTime < System.currentTimeMillis() - timeInMilisToCleanUnusedFiles) {
+            	fileCache.clear(System.currentTimeMillis() - timeInMilisToCleanUnusedFiles);
+            	prefs.edit().putLong(LAST_CLEAN_UP_TIME_KEY, System.currentTimeMillis()).commit();
+            }
+		}
+
+		/**
+		 * After {@link #timeInMilisToCheckChanges} ask server for changes in this image.
+		 */
+		private void askServerFoChanges(int targetDensity) {
+			Bitmap bmp;
+			File f = fileCache.getFile(photoToLoad.url);
+            if(f != null) {
+	            long fLastModified = f.lastModified();
+	            //time to ask server for changes?
+	            if(fLastModified < System.currentTimeMillis() - timeInMilisToCheckChanges) {
+	            	bmp = getBitmapFromWeb(photoToLoad.url, targetDensity);
+	            	if(bmp != null && memoryCache != null) {
+	            		memoryCache.put(photoToLoad.url, bmp);
+	            	}
+	            }
+            }
+		}
+
+		private void displayBitmap(Bitmap bmp) {
+			BitmapDisplayer bd=new BitmapDisplayer(bmp, photoToLoad);
+            handler.post(bd);
+		}
     }
     
     boolean imageViewReused(PhotoToLoad photoToLoad){
-        String tag=imageViews.get(photoToLoad.imageView);
-        if(tag==null || !tag.equals(photoToLoad.url))
-            return true;
-        return false;
+    	Object tag = photoToLoad.imageView.getTag();
+    	if(!photoToLoad.url.equals(tag)) {
+    		return true;
+    	} else {
+    		return false;
+    	}
     }
     
     //Used to display bitmap in the UI thread
@@ -151,7 +379,12 @@ public class ImageLoader {
     {
         Bitmap bitmap;
         PhotoToLoad photoToLoad;
-        public BitmapDisplayer(Bitmap b, PhotoToLoad p){bitmap=b;photoToLoad=p;}
+        
+        public BitmapDisplayer(Bitmap b, PhotoToLoad p){
+        	bitmap=b;
+        	photoToLoad=p;
+        }
+        
         public void run()
         {
             if(imageViewReused(photoToLoad))
@@ -159,12 +392,14 @@ public class ImageLoader {
             if(bitmap!=null)
                 photoToLoad.imageView.setImageBitmap(bitmap);
             else
-                photoToLoad.imageView.setImageResource(stub_id);
+                photoToLoad.imageView.setImageResource(stubDrawableId);
         }
     }
 
     public void clearCache() {
-        memoryCache.clear();
+    	if(memoryCache != null) {
+    		memoryCache.clear();
+    	}
         fileCache.clear();
     }
 

--- a/src/com/fedorvlasov/lazylist/LazyAdapter.java
+++ b/src/com/fedorvlasov/lazylist/LazyAdapter.java
@@ -20,7 +20,11 @@ public class LazyAdapter extends BaseAdapter {
         activity = a;
         data=d;
         inflater = (LayoutInflater)activity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-        imageLoader=new ImageLoader(activity.getApplicationContext());
+        imageLoader = new ImageLoader(activity.getApplicationContext(), R.drawable.stub, true, true, 70, 70);
+        imageLoader.setMemoryCacheEnabled(true);
+        //imageLoader.setTimeToCleanUnusedFiles(60000);
+        imageLoader.setTimeToCheckChanges(60);
+        imageLoader.setOriginalImageDensity(0);//don't care about densities
     }
 
     public int getCount() {
@@ -43,7 +47,7 @@ public class LazyAdapter extends BaseAdapter {
         TextView text=(TextView)vi.findViewById(R.id.text);;
         ImageView image=(ImageView)vi.findViewById(R.id.image);
         text.setText("item "+position);
-        imageLoader.DisplayImage(data[position], image);
+        imageLoader.displayImage(data[position], image, activity.getApplicationContext());
         return vi;
     }
 }

--- a/src/com/fedorvlasov/lazylist/MainActivity.java
+++ b/src/com/fedorvlasov/lazylist/MainActivity.java
@@ -41,6 +41,7 @@ public class MainActivity extends Activity {
     };
     
     private String[] mStrings={
+    		"http://files.skoumal.net/01.png",
             "http://a3.twimg.com/profile_images/670625317/aam-logo-v3-twitter.png",
             "http://a3.twimg.com/profile_images/740897825/AndroidCast-350_normal.png",
             "http://a3.twimg.com/profile_images/121630227/Droid_normal.jpg",

--- a/src/com/fedorvlasov/lazylist/MemoryCache.java
+++ b/src/com/fedorvlasov/lazylist/MemoryCache.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import android.graphics.Bitmap;
 
 public class MemoryCache {
+
     private HashMap<String, SoftReference<Bitmap>> cache=new HashMap<String, SoftReference<Bitmap>>();
     
     public Bitmap get(String id){

--- a/src/com/fedorvlasov/lazylist/Utils.java
+++ b/src/com/fedorvlasov/lazylist/Utils.java
@@ -1,10 +1,23 @@
 package com.fedorvlasov.lazylist;
 
+import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import android.content.Context;
+import android.os.Environment;
 
 public class Utils {
-    public static void CopyStream(InputStream is, OutputStream os)
+	
+	private static final String CHARSET = "utf-8";
+	private static final String MD5 = "MD5";
+	
+	private static File externalDirectory;
+	
+    public static void copyStream(InputStream is, OutputStream os)
     {
         final int buffer_size=1024;
         try
@@ -20,4 +33,39 @@ public class Utils {
         }
         catch(Exception ex){}
     }
+    
+    public static String md5(String s) {
+        try {
+            // Create MD5 Hash
+            MessageDigest digest = java.security.MessageDigest.getInstance(MD5);
+            digest.update(s.getBytes(CHARSET));
+            byte messageDigest[] = digest.digest();
+            
+            // Create Hex String
+            StringBuffer hexString = new StringBuffer();
+            for (int i=0; i<messageDigest.length; i++)
+                hexString.append(Integer.toHexString(0xFF & messageDigest[i]));
+            return hexString.toString();
+            
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        } catch (UnsupportedEncodingException e) {
+        	throw new RuntimeException(e);
+		}
+    }
+    
+	public static File getExternalFilesDir(Context context) {
+		if(externalDirectory == null) {
+			try {
+				//for api 8 and above
+				externalDirectory = context.getExternalFilesDir(null); 
+			} catch(Throwable e) {
+				//api less than 8
+				String packageName = context.getPackageName();
+				externalDirectory = new File(Environment.getExternalStorageDirectory(), "/Android/data/" + packageName + "/files/");
+			}
+		}
+
+		return externalDirectory;
+	}
 }


### PR DESCRIPTION
Cache is updated after configured amount of time, implemented as normal image download, but with if-modified-since HTTP header.
Cache files are also deleted when unused for some time.

You can now disable all types of cache (memory, internal, external).

Witch fragments runOnUIThread doesn't work, updated to handler.
