### PR TITLE
Reset cache size after clearing memory cache

### DIFF
--- a/src/com/fedorvlasov/lazylist/MemoryCache.java
+++ b/src/com/fedorvlasov/lazylist/MemoryCache.java
@@ -66,6 +66,7 @@ public class MemoryCache {
 
     public void clear() {
         cache.clear();
+        size = 0;
     }
 
     long getSizeInBytes(Bitmap bitmap) {


### PR DESCRIPTION
This fix should help improve performance of all Android apps that use LazyList.
